### PR TITLE
Bump version of ECharts from 4.6.0 to 4.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>echarts</artifactId>
-    <version>4.6.1-SNAPSHOT</version>
+    <version>4.7.0-SNAPSHOT</version>
     <name>ECharts</name>
     <description>WebJar for ECharts</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>4.6.0</upstream.version>
+        <upstream.version>4.7.0</upstream.version>
         <upstream.url>https://github.com/ecomfe/echarts/archive/${upstream.version}.zip</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>


### PR DESCRIPTION
See https://www.echartsjs.com/en/changelog.html#v4-7-0