### PR TITLE
Bump version of echarts to 5.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,18 +7,18 @@
         <artifactId>oss-parent</artifactId>
         <version>7</version>
     </parent>
-    
+
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>echarts</artifactId>
-    <version>4.9.1-SNAPSHOT</version>
+    <version>5.0.1-SNAPSHOT</version>
     <name>ECharts</name>
     <description>WebJar for ECharts</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>4.9.0</upstream.version>
+        <upstream.version>5.0.1</upstream.version>
         <upstream.url>https://github.com/ecomfe/echarts/archive/${upstream.version}.zip</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>
@@ -49,7 +49,7 @@
         <developerConnection>scm:git:https://github.com/webjars/echarts.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -68,7 +68,7 @@
                                 <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/incubator-echarts-${upstream.version}/dist" />
+                                    <fileset dir="${project.build.directory}/echarts-${upstream.version}/dist" />
                                 </move>
                             </target>
                         </configuration>


### PR DESCRIPTION
Note that the new release is a complete rewrite in Typescript. 
The distribution folder has changed, the contents of the `dist` folder also are slightly different now.  

See https://echarts.apache.org/en/changelog.html#v5-0-1