### PR TITLE
Bump version of echarts from 5.0.1 to 5.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /.idea
 /*.iml
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>5.0.1</upstream.version>
+        <upstream.version>5.0.2</upstream.version>
         <upstream.url>https://github.com/ecomfe/echarts/archive/${upstream.version}.zip</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>


### PR DESCRIPTION
See https://github.com/apache/echarts/releases/tag/5.0.2